### PR TITLE
Add ros1-bridge, ros2node, ros2service, ros2srv

### DIFF
--- a/recipes-ros2/ros1-bridge/ros1-bridge.bb
+++ b/recipes-ros2/ros1-bridge/ros1-bridge.bb
@@ -1,0 +1,68 @@
+SUMMARY = "The ROS1 bridge"
+HOMEPAGE = "https://github.com/ros2/ros1_bridge"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=12c26a18c7f493fdc7e8a93b16b7c04f"
+
+SRCREV = "75f0392e1e0089cf6f5e7acfeb1e5b6c8c7a78f2"
+SRC_URI = "git://github.com/ros2/ros1_bridge.git;protocol=git;"
+
+ROS_BPN = "ros1_bridge"
+
+inherit ament
+inherit python3native
+
+DEPENDS = " \
+    rcl \
+    rclcpp \
+    roscpp \
+    rcl-interfaces \
+    ros2-std-msgs \
+    ros2-nav-msgs \
+    ros2-visualization-msgs \
+    ros2-geometry-msgs \
+    ros2-std-srvs \
+    ros2-stereo-msgs \
+    ros2-shape-msgs \
+    ros2-actionlib-msgs \
+    example-interfaces \
+"
+
+RDEPENDS_${PN} = "\
+    xmlrpcpp \
+    ros2-trajectory-msgs \
+    rostime \
+    roscpp-serialization \
+    ros2-diagnostic-msgs \
+    ros2-nav-msgs \
+    ros2-visualization-msgs \
+    rosconsole \
+    ros2-geometry-msgs \
+    ros2-sensor-msgs \
+    example-interfaces \
+    ros2-std-srvs \
+    cpp-common \
+    boost-system \
+    rclcpp \
+    ros2-stereo-msgs \
+    ros2-shape-msgs \
+    rcl \
+    ros2-actionlib-msgs \
+    rcutils \
+    roscpp \
+    ros2-std-msgs \
+"
+
+S = "${WORKDIR}/git/"
+
+ros_libdir = "${base_prefix}/opt/ros/${ROSDISTRO}/${baselib}"
+
+PKG_CONFIG_PATH .= ":${PKG_CONFIG_DIR}:${STAGING_DIR_HOST}/${ros_libdir}/pkgconfig:${STAGING_DATADIR}/pkgconfig"
+
+PYTHON_SITEPACKAGES_DIR = "${libdir}/${PYTHON_DIR}/site-packages"
+PYTHONPATH_class-native = "${PYTHON_SITEPACKAGES_DIR}"
+
+export PYTHONPATH="${STAGING_DIR_HOST}/${ros_libdir}/python2.7/site-packages:${STAGING_DIR_HOST}/${libdir}/python3.5/site-packages:${STAGING_DIR_NATIVE}/${libdir}/python2.7/site-packages"
+
+export ROS_ROOT="${STAGING_DIR_HOST}/opt/ros/${ROSDISTRO}"
+export AMENT_PREFIX_PATH="${STAGING_DIR_HOST}/usr"
+

--- a/recipes-ros2/ros2cli/ros2cli.inc
+++ b/recipes-ros2/ros2cli/ros2cli.inc
@@ -2,3 +2,5 @@ HOMEPAGE = "https://github.com/ros2/ros2cli"
 
 SRCREV = "df36377ff44695b43390dccf2df5a7bffd012e61"
 SRC_URI = "git://github.com/ros2/ros2cli.git;protocol=git;"
+
+S = "${WORKDIR}/git/${PN}"

--- a/recipes-ros2/ros2cli/ros2cli_git.bb
+++ b/recipes-ros2/ros2cli/ros2cli_git.bb
@@ -3,9 +3,8 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=12c26a18c7f493fdc7e8a93b16b7c04f"
 
 include ros2cli.inc
-
-S = "${WORKDIR}/git/ros2cli"
-
 inherit setuptools3
 
 RDEPENDS_${PN} += "rclpy python3-setuptools ${PYTHON_PN}-xmlrpc ${PYTHON_PN}-pydoc"
+
+FILES_${PN} += "${datadir}/ament_index/*"

--- a/recipes-ros2/ros2cli/ros2node_git.bb
+++ b/recipes-ros2/ros2cli/ros2node_git.bb
@@ -1,4 +1,4 @@
-SUMMARY = "The msg command for ROS 2 command line tools."
+SUMMARY = "The node command for ROS 2 command line tools."
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=12c26a18c7f493fdc7e8a93b16b7c04f"
 

--- a/recipes-ros2/ros2cli/ros2pkg_git.bb
+++ b/recipes-ros2/ros2cli/ros2pkg_git.bb
@@ -4,8 +4,6 @@ LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=12c26a18c7f49
 
 include ros2cli.inc
 
-S = "${WORKDIR}/git/ros2pkg"
-
 inherit setuptools3
 
 RDEPENDS_${PN} += "ros2cli ament-index-python"

--- a/recipes-ros2/ros2cli/ros2run_git.bb
+++ b/recipes-ros2/ros2cli/ros2run_git.bb
@@ -4,8 +4,6 @@ LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=12c26a18c7f49
 
 include ros2cli.inc
 
-S = "${WORKDIR}/git/ros2run"
-
 inherit setuptools3
 
 RDEPENDS_${PN} += "ros2pkg"

--- a/recipes-ros2/ros2cli/ros2service_git.bb
+++ b/recipes-ros2/ros2cli/ros2service_git.bb
@@ -1,4 +1,4 @@
-SUMMARY = "The msg command for ROS 2 command line tools."
+SUMMARY = "The service command for ROS 2 command line tools."
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=12c26a18c7f493fdc7e8a93b16b7c04f"
 

--- a/recipes-ros2/ros2cli/ros2srv_git.bb
+++ b/recipes-ros2/ros2cli/ros2srv_git.bb
@@ -1,4 +1,4 @@
-SUMMARY = "The msg command for ROS 2 command line tools."
+SUMMARY = "The srv command for ROS 2 command line tools."
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=12c26a18c7f493fdc7e8a93b16b7c04f"
 

--- a/recipes-ros2/ros2cli/ros2topic_git.bb
+++ b/recipes-ros2/ros2cli/ros2topic_git.bb
@@ -4,8 +4,6 @@ LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=12c26a18c7f49
 
 include ros2cli.inc
 
-S = "${WORKDIR}/git/ros2topic"
-
 inherit setuptools3
 
 RDEPENDS_${PN} += "ros2msg ${PYTHON_PN}-pyyaml"


### PR DESCRIPTION
:Release Notes:
Add ros1bridge and ros2cli packages

:Detailed Notes:
Add ros2cli packages and ros1 bridge bb recipe
ros1-bridge need to re-define PYTHONPATH to use both python2.7
and python3.5 packages

:Testing Performed:

:QA Notes:

:Issues Addressed:

Change-Id: I95a62ccf5c6920d9e52d1f328cfe4daab312d931