### PR TITLE
Fix PYTHON_SOABI for ros2 packages

### DIFF
--- a/classes/ament.bbclass
+++ b/classes/ament.bbclass
@@ -22,7 +22,8 @@ ROS_BPN ?= "${@d.getVar('BPN', True).replace('-', '_')}"
 
 S = "${WORKDIR}/git/${ROS_BPN}"
 
-EXTRA_OECMAKE_append = " -DBUILD_TESTING=OFF -DPYTHON_SOABI=cpython-35m-${TUNE_ARCH}-${TARGET_OS}${ARMPKGSFX_EABI}"
+PYTHON_SOABI = "cpython-35m-${TUNE_ARCH}-${TARGET_OS}${ARMPKGSFX_EABI}-gnu"
+EXTRA_OECMAKE_append = " -DBUILD_TESTING=OFF -DPYTHON_SOABI=${PYTHON_SOABI}"
 export AMENT_PREFIX_PATH="${STAGING_DIR_HOST}${prefix};${STAGING_DIR_NATIVE}${prefix}"
 
 inherit cmake python3native


### PR DESCRIPTION
:Release Notes:
Fix to add "-gnu" to PYTHON_SOABI definition
This resolves _rclpy packages not found error.
(so name was not compatible)